### PR TITLE
グループ編集機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'jbuilder', '~> 2.5'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem 'pry-rails'
 end
 
 group :development do

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -21,14 +21,14 @@
           box-sizing: border-box;
           
       }
-      .current-group{
+      .member-list{
           height: 18px;
           width: 70px;
           font-size: 12px;
           color: #999999;
-          list-style: none;
+          // list-style: none;
           padding-inline-start: 40px;
-          display: none; 
+          // display: none; 
       }
      }
     .edit-btn{

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -26,4 +26,5 @@ private
   def set_group
     @group = Group.find(params[:group_id])
   end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,4 +16,5 @@ private
   def user_params
     params.require(:user).permit(:name, :email)
   end
+  
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -11,7 +11,7 @@ class Group < ApplicationRecord
         '画像が投稿されています'
       end
     else
-      'まだメッセージはおまへん。'
+      'まだメッセージはありません。'
     end
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,4 +22,6 @@
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right
+      -# = link_to edit_group_path(@group) do
       = f.submit class: 'chat-group-form__action-btn'
+       

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,4 @@
 .chat-group-form
   %h1 チャットグループ編集
   = render partial: 'form', locals: { group: @group }
+  

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,13 +1,18 @@
 .chat-main  
   .main-header 
-    .left-box test
-    - current_user.groups.each do |group|
-      .current-group masa
-     
+    .left-box
+      %h3.group
+        = @group.name
+      %ul.main-header__left-box__member-list
+        Member:
+        %li.group_users
+          - @group.users.each do |user|
+            = user.name
+  
     .edit-btn
-      = link_to "#" do
+      = link_to edit_group_path(@group) do
         .h1 EDIT
-       
+        
   .messages
     = render @messages 
     .message


### PR DESCRIPTION
##what
グループ作成後にもグループ名の変更やメンバーの変更をできるようにする

##why
新規登録者や内容の変更などに対応するため