### PR TITLE
自動更新

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -87,11 +87,11 @@ $(function(){
       //メッセージが入ったHTMLに、入れ物ごと追加
       $('.messages').append(insertHTML);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-    console.log('success');
+    
     }
   })
   .fail(function() {
-    console.log('error');
+    alert("メッセージ送信に失敗しました");
   });
 };
 if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,5 @@
 $(function(){ 
+  
   function buildHTML(message){
     if ( message.image ) {
       var html =
@@ -44,6 +45,7 @@ $(function(){
     e.preventDefault()
     var formData = new FormData(this);
     var url = $(this).attr('action');
+    
     $.ajax({
       url: url, //同期通信でいう『パス』
       type: 'POST',  //同期通信でいう『HTTPメソッド』
@@ -63,4 +65,36 @@ $(function(){
       alert("メッセージ送信に失敗しました");
   });
  })
+ var reloadMessages = function() {
+  //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+  last_message_id = $('.message:last').data("message-id");
+  $.ajax({
+    //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+    url: "api/messages",
+    //ルーティングで設定した通りhttpメソッドをgetに指定
+    type: 'get',
+    dataType: 'json',
+    //dataオプションでリクエストに値を含める
+    data: {id: last_message_id}
+  })
+  .done(function(messages) {
+    if (messages.length !== 0) {
+    var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      //メッセージが入ったHTMLに、入れ物ごと追加
+      $('.messages').append(insertHTML);
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+   
+    }
+  })
+  .fail(function() {
+   
+  });
+};
+if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages, 3000);
+}
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -87,14 +87,14 @@ $(function(){
       //メッセージが入ったHTMLに、入れ物ごと追加
       $('.messages').append(insertHTML);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-   
+    console.log('success');
     }
   })
   .fail(function() {
-   
+    console.log('error');
   });
 };
 if (document.location.href.match(/\/groups\/\d+\/messages/)) {
-  setInterval(reloadMessages, 3000);
+  setInterval(reloadMessages, 7000);
 }
 })

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .main-header
     .left-box
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update] 
   resources :groups, only: [ :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create] 
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
     
   end
 end


### PR DESCRIPTION
##WHAT
自分以外のユーザーがメッセージを投稿した場合にリロードせずにメッセージを確認できるように。

##WHY
リロードせずにメッセージを確認できるのがチャットアプリの基本的な機能だから。